### PR TITLE
Update .bo domain names

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -395,6 +395,39 @@ org.bo
 net.bo
 mil.bo
 tv.bo
+// bo : http://www.nic.bo/ Social Domains 
+academia.bo
+agro.bo
+arte.bo
+blog.bo
+bolivia.bo
+ciencia.bo
+cooperativa.bo
+democracia.bo
+deporte.bo
+ecologia.bo
+economia.bo
+empresa.bo
+indigena.bo
+industria.bo
+info.bo
+medicina.bo
+movimiento.bo
+musica.bo
+natural.bo
+nombre.bo
+noticias.bo
+patria.bo
+politica.bo
+profesional.bo
+plurinacional.bo
+pueblo.bo
+revista.bo
+salud.bo
+tecnologia.bo
+tksat.bo
+transporte.bo
+wiki.bo
 
 // br : http://registro.br/dominio/categoria.html
 // Submitted by registry <fneves@registro.br>

--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -394,6 +394,7 @@ org.bo
 net.bo
 mil.bo
 tv.bo
+web.bo
 // bo : http://www.nic.bo/ Social Domains 
 academia.bo
 agro.bo

--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -388,7 +388,6 @@ org.bm
 bo
 com.bo
 edu.bo
-gov.bo
 gob.bo
 int.bo
 org.bo


### PR DESCRIPTION
Hi,

These are the new SDLs managed by nic.bo.
I do not work for nic.bo, I just want to contribute to the project.
For more information you can go to https://nic.bo/delegacion2015.php#h-1.10 .
Unfortunately I was not able to find documentation in English.

As you can see, the new SDLs are alredy working.
pro-imagen.tecnologia.bo

Also, since 2011 gov.bo it is not a valid SDL.
In the same document https://nic.bo/delegacion2015.php#h-1.10, below the social domains you can check the restricted domains:

Dominio.gob.bo
Dominio.edu.bo
Dominio.mil.bo
Dominio.int.bo

As you can see, gov.bo is not longer available.

Added web.bo, also listed in the same document.

Here are some other contributions that I have made to the list:
#406
#42

Regards.